### PR TITLE
Add UART activity indicator to Debug screen

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -116,7 +116,8 @@ impl MaraUiApp for MaraUi {
     }
 
     fn backlight_active(&self) -> bool {
-        self.state.backlight_should_be_on(Instant::now())
+        self.state.current_screen == Screen::Debug
+            || self.state.backlight_should_be_on(Instant::now())
     }
 
     fn current_screen(&self) -> Screen {

--- a/src/screens/debug.rs
+++ b/src/screens/debug.rs
@@ -2,9 +2,12 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::text::{Line, Text};
 use ratatui::widgets::Paragraph;
 use ratatui::{Frame, widgets::Widget};
+use std::time::{Duration, Instant};
 
 use crate::screens::screen::Board;
 use crate::state::GlobalAppState;
+
+const UART_ACTIVITY_FLASH: Duration = Duration::from_millis(250);
 
 /// Debug screen showing raw UART telemetry data
 #[derive(Default)]
@@ -26,9 +29,15 @@ impl Board for Debug {
             state.wifi_status, state.mqtt_status
         );
 
+        let now = Instant::now();
+        let activity_marker = match state.last_uart_frame_at {
+            Some(t) if now.saturating_duration_since(t) < UART_ACTIVITY_FLASH => "●",
+            _ => " ",
+        };
+
         let text = match &state.machine_state.last_frame {
-            Some(telemetry) => format!("UART: {}", telemetry.raw_string),
-            None => "UART: No data (waiting for connection...)".to_string(),
+            Some(telemetry) => format!("UART{} {}", activity_marker, telemetry.raw_string),
+            None => format!("UART{}No data (waiting for connection...)", activity_marker),
         };
 
         let lines = state.events_log.iter().map(|s| Line::from(s.to_string()));

--- a/src/state/fsm.rs
+++ b/src/state/fsm.rs
@@ -226,6 +226,7 @@ impl AppStateMachine {
         // Store the latest telemetry frame and record activity time
         state.machine_state.last_frame = Some(frame);
         state.last_activity_at = Some(now);
+        state.last_uart_frame_at = Some(now);
 
         // Process each event through the FSM
         for event in events {

--- a/src/state/global_state.rs
+++ b/src/state/global_state.rs
@@ -119,6 +119,8 @@ pub struct GlobalAppState {
     pub screen_before_debug: Option<Screen>,
     /// Last time UART telemetry or a button press was received (for backlight timeout)
     pub last_activity_at: Option<Instant>,
+    /// Last time a UART telemetry frame was received (for Debug screen activity marker)
+    pub last_uart_frame_at: Option<Instant>,
 }
 
 impl Default for GlobalAppState {
@@ -137,6 +139,7 @@ impl Default for GlobalAppState {
             return_to_screen_at: None,
             screen_before_debug: None,
             last_activity_at: None,
+            last_uart_frame_at: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a visual activity indicator to the Debug screen that flashes when UART telemetry frames are received, and ensures the backlight stays on while viewing the Debug screen.

## Key Changes
- **Debug screen activity marker**: Added a flashing bullet point (●) indicator that appears for 250ms after each UART frame is received, providing visual feedback of telemetry data arrival
- **Separate UART activity tracking**: Introduced `last_uart_frame_at` field to track UART frame reception independently from general activity (button presses), allowing the Debug screen to display frame-specific activity
- **Debug screen backlight behavior**: Modified backlight logic to keep the backlight on whenever the Debug screen is active, regardless of inactivity timeout
- **Activity constant**: Defined `UART_ACTIVITY_FLASH` constant (250ms) to control the duration of the activity indicator flash

## Implementation Details
- The activity marker uses `Instant::now().saturating_duration_since()` to safely calculate elapsed time since the last UART frame
- The indicator displays as a bullet point (●) when active and a space when inactive, maintaining consistent formatting
- The backlight now uses an OR condition: stays on if Debug screen is active OR if the normal activity timeout hasn't expired

https://claude.ai/code/session_017VPAG4hjRxPHPNbBdFJDGp