### PR TITLE
Fix logic error in screen state transition condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  # Override rust-toolchain.toml (which pins to the ESP toolchain) so that
+  # simulator/host builds use standard stable Rust on CI runners.
+  RUSTUP_TOOLCHAIN: stable
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SDL2
+        run: sudo apt-get update && sudo apt-get install -y libsdl2-dev
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: cargo test --no-default-features --features simulator --target x86_64-unknown-linux-gnu
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SDL2
+        run: sudo apt-get update && sudo apt-get install -y libsdl2-dev
+
+      - name: Install Rust stable with clippy
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-
+            ${{ runner.os }}-cargo-
+
+      - name: Run Clippy
+        run: cargo clippy --no-default-features --features simulator --target x86_64-unknown-linux-gnu -- -D warnings
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable with rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check

--- a/src/screens/screen.rs
+++ b/src/screens/screen.rs
@@ -28,7 +28,7 @@ impl Screen {
         let screens = Self::rotatable();
         let pos = screens.iter().position(|s| *s == self);
         match pos {
-            Some(i) if i == 0 => screens[screens.len() - 1],
+            Some(0) => screens[screens.len() - 1],
             Some(i) => screens[i - 1],
             None => Screen::Main,
         }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -378,7 +378,12 @@ fn init_networking(
     }
 
     info!("MQTT started: {}", app_config.mqtt.url);
-    (Some(esp_wifi), Some(mqtt_client), Some(cup_counter_rx), Some(mqtt_status_rx))
+    (
+        Some(esp_wifi),
+        Some(mqtt_client),
+        Some(cup_counter_rx),
+        Some(mqtt_status_rx),
+    )
 }
 
 fn publish_mqtt_message(

--- a/src/setup_simulator.rs
+++ b/src/setup_simulator.rs
@@ -1,7 +1,7 @@
 use crate::app::MaraUiApp;
 use crate::button::{Button, ButtonPressType};
-use crate::screens::Screen;
 use crate::config::AppConfig;
+use crate::screens::Screen;
 use crate::state::{AppEvent, ConnectionStatus};
 use crate::telemetry::TelemetryFrame;
 use mousefood::embedded_graphics::prelude::Size;
@@ -155,7 +155,11 @@ fn run_app_simulator(mut app: impl MaraUiApp) {
 
 fn init_simulator_mqtt(
     cfg: &AppConfig,
-) -> (Option<Client>, Option<Receiver<u64>>, Option<Receiver<ConnectionStatus>>) {
+) -> (
+    Option<Client>,
+    Option<Receiver<u64>>,
+    Option<Receiver<ConnectionStatus>>,
+) {
     if !cfg.mqtt.enabled {
         return (None, None, None);
     }
@@ -187,12 +191,11 @@ fn init_simulator_mqtt(
                     let _ = mqtt_status_tx.send(ConnectionStatus::Connecting);
                 }
                 Ok(Event::Incoming(Packet::Publish(publish))) => {
-                    if publish.topic == cup_counter_topic {
-                        if let Ok(payload) = core::str::from_utf8(&publish.payload)
-                            && let Ok(cups) = payload.trim().parse::<u64>()
-                        {
-                            let _ = cup_counter_tx.send(cups);
-                        }
+                    if publish.topic == cup_counter_topic
+                        && let Ok(payload) = core::str::from_utf8(&publish.payload)
+                        && let Ok(cups) = payload.trim().parse::<u64>()
+                    {
+                        let _ = cup_counter_tx.send(cups);
                     }
                 }
                 _ => {}

--- a/src/state/fsm.rs
+++ b/src/state/fsm.rs
@@ -33,7 +33,7 @@ impl AppStateMachine {
                 state.error = None;
                 // Auto-switch to Dashboard and remember where to return
                 if state.current_screen != Screen::Dashboard
-                    || state.current_screen != Screen::Debug
+                    && state.current_screen != Screen::Debug
                 {
                     state.screen_before_extraction = Some(state.current_screen);
                     state.return_to_screen_at = None;

--- a/src/state/fsm.rs
+++ b/src/state/fsm.rs
@@ -249,13 +249,13 @@ impl AppStateMachine {
 
     /// Check time-based transitions (call once per main loop iteration)
     pub fn tick(state: &mut GlobalAppState, now: Instant) {
-        if let Some(return_at) = state.return_to_screen_at {
-            if now >= return_at {
-                if let Some(screen) = state.screen_before_extraction.take() {
-                    state.current_screen = screen;
-                }
-                state.return_to_screen_at = None;
+        if let Some(return_at) = state.return_to_screen_at
+            && now >= return_at
+        {
+            if let Some(screen) = state.screen_before_extraction.take() {
+                state.current_screen = screen;
             }
+            state.return_to_screen_at = None;
         }
     }
 }

--- a/src/state/global_state.rs
+++ b/src/state/global_state.rs
@@ -8,19 +8,14 @@ use std::{
 pub const EXTRACTION_RETURN_DELAY: Duration = Duration::from_secs(5);
 pub const BACKLIGHT_TIMEOUT: Duration = Duration::from_secs(10);
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum ConnectionStatus {
     Disabled,
+    #[default]
     Disconnected,
     Connecting,
     Connected,
     Error(String),
-}
-
-impl Default for ConnectionStatus {
-    fn default() -> Self {
-        Self::Disconnected
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod telemetry;
 pub use telemetry::{
     AppEvent, MachineMode, MachineState, Snapshot, TelemetryFrame, parse_uart_line,

--- a/src/telemetry/telemetry.rs
+++ b/src/telemetry/telemetry.rs
@@ -255,13 +255,13 @@ pub fn update_state_with_events(
     };
 
     // 1) Mode change event
-    if let Some(pm) = prev_mode {
-        if pm != frame.mode {
-            events.push(AppEvent::ModeChanged {
-                from: pm,
-                to: frame.mode,
-            });
-        }
+    if let Some(pm) = prev_mode
+        && pm != frame.mode
+    {
+        events.push(AppEvent::ModeChanged {
+            from: pm,
+            to: frame.mode,
+        });
     }
 
     // 2) Pump timer + shot start/end events
@@ -278,7 +278,7 @@ pub fn update_state_with_events(
             // Shot ended
             let duration = state
                 .shot_started_at
-                .map(|started_at| now.saturating_duration_since(started_at).as_secs() as u64)
+                .map(|started_at| now.saturating_duration_since(started_at).as_secs())
                 .unwrap_or(0);
             state.shot_started_at = None;
             events.push(AppEvent::ShotEnded { duration });


### PR DESCRIPTION
## Summary
This PR fixes a critical logic error in the app state machine that was preventing proper screen state transitions during extraction operations.

## Key Changes
- **Fixed boolean logic in `src/state/fsm.rs`**: Changed OR operator (`||`) to AND operator (`&&`) in the screen transition condition. The original logic with OR would always evaluate to true (since a value cannot simultaneously equal two different enum variants), preventing the auto-switch to Dashboard from working correctly.
- **Added CI/CD pipeline**: Introduced GitHub Actions workflow (`.github/workflows/ci.yml`) to run tests, clippy linting, and format checks on push and pull requests to the main branch.

## Implementation Details
The bug was in the condition that determines whether to auto-switch to the Dashboard screen and remember the current screen for later return. The original condition:
```rust
if state.current_screen != Screen::Dashboard || state.current_screen != Screen::Debug
```
would always be true because `current_screen` cannot be unequal to both Dashboard AND Debug simultaneously. The fix changes this to:
```rust
if state.current_screen != Screen::Dashboard && state.current_screen != Screen::Debug
```
This now correctly checks that the current screen is neither Dashboard nor Debug before performing the auto-switch logic.

https://claude.ai/code/session_0137jQTLwSGjoPGxtHwHrC46