### PR TITLE
feat(status): board metadata via MQTT — Wi-Fi RSSI, IP, uptime, free heap

### DIFF
--- a/docs/node-red-ha-bridge.json
+++ b/docs/node-red-ha-bridge.json
@@ -4,7 +4,7 @@
         "type": "tab",
         "label": "MaraTUI → HA",
         "disabled": false,
-        "info": "MQTT bridge: Lelit Mara (MaraTUI) → Home Assistant via MQTT Discovery.\nSubscribes to maratui/telemetry and maratui/events.\nPublishes HA discovery configs on deploy, then streams state updates."
+        "info": "MQTT bridge: Lelit Mara (MaraTUI) → Home Assistant via MQTT Discovery.\nSubscribes to maratui/telemetry, maratui/events, maratui/status.\nPublishes HA discovery configs on deploy, then streams state updates."
     },
     {
         "id": "broker_maratui",
@@ -55,7 +55,7 @@
         "type": "function",
         "z": "tab_maratui",
         "name": "Build HA Discovery",
-        "func": "const DEVICE = {\n    identifiers: ['maratui_esp32'],\n    name: 'Lelit Mara',\n    model: 'MaraTUI',\n    manufacturer: 'Lelit'\n};\n\nfunction sensor(id, name, extra) {\n    return {\n        topic: `homeassistant/sensor/maratui_${id}/config`,\n        payload: JSON.stringify(Object.assign({\n            name: name,\n            unique_id: `maratui_${id}`,\n            state_topic: `homeassistant/sensor/maratui_${id}/state`,\n            device: DEVICE\n        }, extra)),\n        qos: 1,\n        retain: true\n    };\n}\n\nfunction binary(id, name, extra) {\n    return {\n        topic: `homeassistant/binary_sensor/maratui_${id}/config`,\n        payload: JSON.stringify(Object.assign({\n            name: name,\n            unique_id: `maratui_${id}`,\n            state_topic: `homeassistant/binary_sensor/maratui_${id}/state`,\n            payload_on: 'ON',\n            payload_off: 'OFF',\n            device: DEVICE\n        }, extra)),\n        qos: 1,\n        retain: true\n    };\n}\n\nconst msgs = [\n    sensor('mode', 'Mode', { icon: 'mdi:coffee-maker' }),\n    sensor('firmware', 'Firmware Version', { icon: 'mdi:chip', entity_category: 'diagnostic' }),\n    sensor('boiler_now', 'Boiler Temperature', {\n        unit_of_measurement: '\\u00b0C',\n        device_class: 'temperature',\n        state_class: 'measurement'\n    }),\n    sensor('boiler_target', 'Boiler Target', {\n        unit_of_measurement: '\\u00b0C',\n        device_class: 'temperature',\n        state_class: 'measurement'\n    }),\n    sensor('hx_now', 'HX Temperature', {\n        unit_of_measurement: '\\u00b0C',\n        device_class: 'temperature',\n        state_class: 'measurement'\n    }),\n    sensor('last_extraction_duration', 'Last Extraction Duration', {\n        unit_of_measurement: 's',\n        icon: 'mdi:coffee',\n        state_class: 'measurement'\n    }),\n    sensor('extraction_timer', 'Extraction Timer', {\n        unit_of_measurement: 's',\n        icon: 'mdi:timer-play',\n        state_class: 'measurement',\n        force_update: true\n    }),\n    sensor('time_since_last_shot', 'Time Since Last Shot', {\n        unit_of_measurement: 'min',\n        icon: 'mdi:clock-outline',\n        state_class: 'measurement'\n    }),\n    binary('heating', 'Heating', { device_class: 'heat' }),\n    binary('pump', 'Pump Active', { icon: 'mdi:pump' }),\n    binary('water_low', 'Water Level Low', { device_class: 'problem' })\n];\n\nreturn [msgs];",
+        "func": "const DEVICE = {\n    identifiers: ['maratui_esp32'],\n    name: 'Lelit Mara',\n    model: 'MaraTUI',\n    manufacturer: 'Lelit'\n};\n\nfunction sensor(id, name, extra) {\n    return {\n        topic: `homeassistant/sensor/maratui_${id}/config`,\n        payload: JSON.stringify(Object.assign({\n            name: name,\n            unique_id: `maratui_${id}`,\n            state_topic: `homeassistant/sensor/maratui_${id}/state`,\n            device: DEVICE\n        }, extra)),\n        qos: 1,\n        retain: true\n    };\n}\n\nfunction binary(id, name, extra) {\n    return {\n        topic: `homeassistant/binary_sensor/maratui_${id}/config`,\n        payload: JSON.stringify(Object.assign({\n            name: name,\n            unique_id: `maratui_${id}`,\n            state_topic: `homeassistant/binary_sensor/maratui_${id}/state`,\n            payload_on: 'ON',\n            payload_off: 'OFF',\n            device: DEVICE\n        }, extra)),\n        qos: 1,\n        retain: true\n    };\n}\n\nconst msgs = [\n    sensor('mode', 'Mode', { icon: 'mdi:coffee-maker' }),\n    sensor('firmware', 'Firmware Version', { icon: 'mdi:chip', entity_category: 'diagnostic' }),\n    sensor('boiler_now', 'Boiler Temperature', {\n        unit_of_measurement: '\\u00b0C',\n        device_class: 'temperature',\n        state_class: 'measurement'\n    }),\n    sensor('boiler_target', 'Boiler Target', {\n        unit_of_measurement: '\\u00b0C',\n        device_class: 'temperature',\n        state_class: 'measurement'\n    }),\n    sensor('hx_now', 'HX Temperature', {\n        unit_of_measurement: '\\u00b0C',\n        device_class: 'temperature',\n        state_class: 'measurement'\n    }),\n    sensor('last_extraction_duration', 'Last Extraction Duration', {\n        unit_of_measurement: 's',\n        icon: 'mdi:coffee',\n        state_class: 'measurement'\n    }),\n    sensor('extraction_timer', 'Extraction Timer', {\n        unit_of_measurement: 's',\n        icon: 'mdi:timer-play',\n        state_class: 'measurement',\n        force_update: true\n    }),\n    sensor('time_since_last_shot', 'Time Since Last Shot', {\n        unit_of_measurement: 'min',\n        icon: 'mdi:clock-outline',\n        state_class: 'measurement'\n    }),\n    binary('heating', 'Heating', { device_class: 'heat' }),\n    binary('pump', 'Pump Active', { icon: 'mdi:pump' }),\n    binary('water_low', 'Water Level Low', { device_class: 'problem' }),\n    sensor('uptime', 'Uptime', {\n        unit_of_measurement: 'min',\n        icon: 'mdi:timer-outline',\n        state_class: 'total_increasing',\n        entity_category: 'diagnostic'\n    }),\n    sensor('wifi_rssi', 'Wi-Fi RSSI', {\n        unit_of_measurement: 'dBm',\n        device_class: 'signal_strength',\n        state_class: 'measurement',\n        entity_category: 'diagnostic'\n    }),\n    sensor('wifi_ssid', 'Wi-Fi SSID', {\n        icon: 'mdi:wifi',\n        entity_category: 'diagnostic'\n    }),\n    sensor('ip', 'IP Address', {\n        icon: 'mdi:ip-network',\n        entity_category: 'diagnostic'\n    }),\n    sensor('free_heap', 'Free Heap', {\n        unit_of_measurement: 'kB',\n        icon: 'mdi:memory',\n        state_class: 'measurement',\n        entity_category: 'diagnostic'\n    })\n];\n\nreturn [msgs];",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -130,6 +130,38 @@
         "wires": [["mqtt_out"]]
     },
     {
+        "id": "mqtt_in_status",
+        "type": "mqtt in",
+        "z": "tab_maratui",
+        "name": "mara/status",
+        "topic": "mara/status",
+        "qos": "0",
+        "datatype": "json",
+        "broker": "broker_maratui",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 160,
+        "y": 500,
+        "wires": [["fn_status"]]
+    },
+    {
+        "id": "fn_status",
+        "type": "function",
+        "z": "tab_maratui",
+        "name": "Parse Status",
+        "func": "const d = msg.payload;\nif (!d) return null;\n\nfunction s(id, val) {\n    if (val === null || val === undefined) return null;\n    return {\n        topic: `homeassistant/sensor/maratui_${id}/state`,\n        payload: String(val),\n        qos: 0,\n        retain: false\n    };\n}\n\nconst msgs = [\n    s('uptime', Math.round(d.uptime_s / 60)),\n    s('wifi_rssi', d.wifi_rssi),\n    s('wifi_ssid', d.wifi_ssid),\n    s('ip', d.ip),\n    d.free_heap_b != null ? s('free_heap', Math.round(d.free_heap_b / 1024)) : null\n].filter(Boolean);\n\nreturn [msgs];",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 370,
+        "y": 500,
+        "wires": [["mqtt_out"]]
+    },
+    {
         "id": "mqtt_out",
         "type": "mqtt out",
         "z": "tab_maratui",
@@ -144,7 +176,7 @@
         "expiry": "",
         "broker": "broker_maratui",
         "x": 590,
-        "y": 220,
+        "y": 300,
         "wires": []
     }
 ]

--- a/src/screens/debug.rs
+++ b/src/screens/debug.rs
@@ -17,7 +17,9 @@ impl Board for Debug {
     fn render(state: &GlobalAppState, area: Rect, frame: &mut Frame) {
         let buf = frame.buffer_mut();
 
-        let [net_line, uart_line, log_area] = Layout::vertical([
+        let [net_line, dev_line1, dev_line2, uart_line, log_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
             Constraint::Length(1),
             Constraint::Length(1),
             Constraint::Min(1),
@@ -28,6 +30,20 @@ impl Board for Debug {
             "NET: Wi-Fi={:?} MQTT={:?}",
             state.wifi_status, state.mqtt_status
         );
+
+        let dev = &state.device_info;
+        let rssi_str = dev
+            .wifi_rssi
+            .map(|v| format!("{}dBm", v))
+            .unwrap_or_else(|| "?".to_string());
+        let ip_str = dev.ip.as_deref().unwrap_or("?");
+        let heap_str = dev
+            .free_heap_b
+            .map(|v| format!("{}kB", v / 1024))
+            .unwrap_or_else(|| "N/A".to_string());
+        // ~45 chars per line at 7px/char on 320px display
+        let dev_text1 = format!("DEV: ssid={} rssi={}", dev.wifi_ssid, rssi_str);
+        let dev_text2 = format!("     ip={} up={}s heap={}", ip_str, dev.uptime_s, heap_str);
 
         let now = Instant::now();
         let activity_marker = match state.last_uart_frame_at {
@@ -43,6 +59,8 @@ impl Board for Debug {
         let lines = state.events_log.iter().map(|s| Line::from(s.to_string()));
 
         Paragraph::new(vec![Line::from(net_text)]).render(net_line, buf);
+        Paragraph::new(vec![Line::from(dev_text1)]).render(dev_line1, buf);
+        Paragraph::new(vec![Line::from(dev_text2)]).render(dev_line2, buf);
         Paragraph::new(vec![Line::from(text)]).render(uart_line, buf);
         Paragraph::new(Text::from_iter(lines)).render(log_area, buf);
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2,7 +2,7 @@ use crate::app::MaraUiApp;
 use crate::button::{Button, ButtonState};
 use crate::config::AppConfig;
 use crate::screens::Screen;
-use crate::state::{AppEvent, ConnectionStatus};
+use crate::state::{AppEvent, ConnectionStatus, DeviceInfo};
 use crate::telemetry::TelemetryFrame;
 use mousefood::embedded_graphics::Drawable;
 use mousefood::embedded_graphics::image::{Image, ImageRaw, ImageRawBE};
@@ -33,7 +33,7 @@ use esp_idf_svc::wifi::{
 use ili9341::{DisplaySize240x320, Ili9341, Orientation};
 use log::{info, warn};
 use std::sync::mpsc::{self, Receiver};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 type DisplayResult<'a> = anyhow::Result<
     Ili9341<
@@ -139,8 +139,10 @@ fn run_app_hardware(mut app: impl MaraUiApp) {
     app.handle_event(AppEvent::WifiStatusChanged(ConnectionStatus::Connecting));
     app.handle_event(AppEvent::MqttStatusChanged(ConnectionStatus::Connecting));
 
-    let (_wifi, mut mqtt_client, mut cup_counter_rx, mut mqtt_status_rx) =
+    let (_wifi, mut mqtt_client, mut cup_counter_rx, mut mqtt_status_rx, initial_ip) =
         init_networking(modem, &app_config);
+    let boot_time = Instant::now();
+    let mut last_status_at: Option<Instant> = None;
 
     app.handle_event(AppEvent::WifiStatusChanged(ConnectionStatus::Connected));
     if mqtt_client.is_none() {
@@ -226,6 +228,26 @@ fn run_app_hardware(mut app: impl MaraUiApp) {
             }
         }
 
+        let now = Instant::now();
+        let should_publish_status = last_status_at
+            .map(|t| now.saturating_duration_since(t) >= STATUS_INTERVAL)
+            .unwrap_or(true);
+        if should_publish_status {
+            last_status_at = Some(now);
+            let ssid = app_config
+                .wifi
+                .as_ref()
+                .map(|w| w.ssid.clone())
+                .unwrap_or_default();
+            app.handle_event(AppEvent::DeviceInfoUpdated(DeviceInfo {
+                wifi_ssid: ssid,
+                wifi_rssi: query_wifi_rssi(),
+                ip: initial_ip.clone(),
+                uptime_s: now.saturating_duration_since(boot_time).as_secs(),
+                free_heap_b: Some(query_free_heap()),
+            }));
+        }
+
         for (topic_suffix, payload) in app.take_outbound_mqtt_messages() {
             publish_mqtt_message(&mut mqtt_client, &app_config, &topic_suffix, &payload);
         }
@@ -250,6 +272,21 @@ fn run_app_hardware(mut app: impl MaraUiApp) {
     }
 }
 
+const STATUS_INTERVAL: Duration = Duration::from_secs(30);
+
+fn query_wifi_rssi() -> Option<i32> {
+    let mut ap_info: esp_idf_svc::sys::wifi_ap_record_t = unsafe { core::mem::zeroed() };
+    if unsafe { esp_idf_svc::sys::esp_wifi_sta_get_ap_info(&mut ap_info) } == 0 {
+        Some(i32::from(ap_info.rssi))
+    } else {
+        None
+    }
+}
+
+fn query_free_heap() -> u32 {
+    unsafe { esp_idf_svc::sys::esp_get_free_heap_size() }
+}
+
 fn init_networking(
     modem: esp_idf_svc::hal::modem::Modem,
     app_config: &AppConfig,
@@ -258,6 +295,7 @@ fn init_networking(
     Option<EspMqttClient<'static>>,
     Option<Receiver<u64>>,
     Option<Receiver<ConnectionStatus>>,
+    Option<String>,
 ) {
     let sys_loop = EspSystemEventLoop::take().expect("Failed to take system event loop");
     let nvs = EspDefaultNvsPartition::take().ok();
@@ -314,11 +352,16 @@ fn init_networking(
         wifi.wait_netif_up().expect("Failed to obtain IP");
     }
 
-    info!("Wi-Fi connected");
+    let initial_ip = esp_wifi
+        .sta_netif()
+        .get_ip_info()
+        .ok()
+        .map(|info| info.ip.to_string());
+    info!("Wi-Fi connected, IP: {:?}", initial_ip);
 
     if !app_config.mqtt.enabled {
         info!("MQTT is disabled by MARATUI_MQTT_ENABLED");
-        return (Some(esp_wifi), None, None, None);
+        return (Some(esp_wifi), None, None, None, initial_ip);
     }
 
     let cup_counter_topic = format!("{}/cup_counter", app_config.mqtt.topic_prefix);
@@ -391,6 +434,7 @@ fn init_networking(
         Some(mqtt_client),
         Some(cup_counter_rx),
         Some(mqtt_status_rx),
+        initial_ip,
     )
 }
 

--- a/src/setup_simulator.rs
+++ b/src/setup_simulator.rs
@@ -2,7 +2,7 @@ use crate::app::MaraUiApp;
 use crate::button::{Button, ButtonPressType};
 use crate::config::AppConfig;
 use crate::screens::Screen;
-use crate::state::{AppEvent, ConnectionStatus};
+use crate::state::{AppEvent, ConnectionStatus, DeviceInfo};
 use crate::telemetry::TelemetryFrame;
 use mousefood::embedded_graphics::prelude::Size;
 use mousefood::fonts::*;
@@ -13,7 +13,7 @@ use rumqttc::{Client, Event, MqttOptions, Packet, QoS};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::mpsc::{self, Receiver};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use embedded_graphics_simulator::{
     OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
@@ -59,6 +59,10 @@ fn run_app_simulator(mut app: impl MaraUiApp) {
     } else {
         app.handle_event(AppEvent::MqttStatusChanged(ConnectionStatus::Disabled));
     }
+
+    const STATUS_INTERVAL: Duration = Duration::from_secs(30);
+    let boot_time = Instant::now();
+    let mut last_status_at: Option<Instant> = None;
 
     loop {
         let screen_before = app.current_screen();
@@ -135,6 +139,26 @@ fn run_app_simulator(mut app: impl MaraUiApp) {
             while let Ok(status) = status_rx.try_recv() {
                 app.handle_event(AppEvent::MqttStatusChanged(status));
             }
+        }
+
+        let now = Instant::now();
+        let should_publish_status = last_status_at
+            .map(|t| now.saturating_duration_since(t) >= STATUS_INTERVAL)
+            .unwrap_or(true);
+        if should_publish_status {
+            last_status_at = Some(now);
+            let ssid = app_config
+                .wifi
+                .as_ref()
+                .map(|w| w.ssid.clone())
+                .unwrap_or_else(|| "simulator".to_string());
+            app.handle_event(AppEvent::DeviceInfoUpdated(DeviceInfo {
+                wifi_ssid: ssid,
+                wifi_rssi: Some(-65),
+                ip: Some("127.0.0.1".to_string()),
+                uptime_s: now.saturating_duration_since(boot_time).as_secs(),
+                free_heap_b: None,
+            }));
         }
 
         let (_, mqtt_status) = app.connection_statuses();

--- a/src/state/app_events.rs
+++ b/src/state/app_events.rs
@@ -1,6 +1,6 @@
 use crate::telemetry::AppEvent as TelemetryEvent;
 
-use super::ConnectionStatus;
+use super::{ConnectionStatus, DeviceInfo};
 
 /// Application events
 /// Combines telemetry events and UI events
@@ -55,6 +55,9 @@ pub enum AppEvent {
         topic_suffix: String,
         payload: String,
     },
+
+    /// Board metadata update (WiFi RSSI, IP, uptime, free heap)
+    DeviceInfoUpdated(DeviceInfo),
 }
 
 impl AppEvent {
@@ -125,6 +128,9 @@ impl std::fmt::Display for AppEvent {
                 "Publish MQTT event: suffix='{}' payload='{}'",
                 topic_suffix, payload
             ),
+            AppEvent::DeviceInfoUpdated(info) => {
+                write!(f, "Device info updated (uptime={}s)", info.uptime_s)
+            }
         }
     }
 }

--- a/src/state/fsm.rs
+++ b/src/state/fsm.rs
@@ -1,7 +1,8 @@
 use log::{error, info};
 
 use super::{
-    AppError, AppEvent, ExtractionState, GlobalAppState, global_state::EXTRACTION_RETURN_DELAY,
+    AppError, AppEvent, DeviceInfo, ExtractionState, GlobalAppState,
+    global_state::EXTRACTION_RETURN_DELAY,
 };
 use crate::button::{Button, ButtonPressType};
 use crate::screens::Screen;
@@ -116,6 +117,12 @@ impl AppStateMachine {
                 payload,
             } => {
                 state.enqueue_mqtt_message(topic_suffix, payload);
+            }
+
+            AppEvent::DeviceInfoUpdated(info) => {
+                let payload = device_status_payload(&info);
+                state.device_info = info;
+                state.enqueue_mqtt_message("status", payload);
             }
         }
     }
@@ -235,6 +242,26 @@ fn push_triple(buf: &mut std::collections::VecDeque<f64>, value: f64) {
     while buf.len() > GRAPH_BUF_CAP {
         buf.pop_front();
     }
+}
+
+fn device_status_payload(info: &DeviceInfo) -> String {
+    let rssi = info
+        .wifi_rssi
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    let ip = info
+        .ip
+        .as_deref()
+        .map(|s| format!("\"{}\"", s))
+        .unwrap_or_else(|| "null".to_string());
+    let heap = info
+        .free_heap_b
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    format!(
+        "{{\"uptime_s\":{},\"wifi_ssid\":\"{}\",\"wifi_rssi\":{},\"ip\":{},\"free_heap_b\":{}}}",
+        info.uptime_s, info.wifi_ssid, rssi, ip, heap,
+    )
 }
 
 fn telemetry_event_payload(event: &crate::telemetry::AppEvent) -> String {

--- a/src/state/global_state.rs
+++ b/src/state/global_state.rs
@@ -69,6 +69,16 @@ impl ExtractionState {
     }
 }
 
+/// Board metadata published to MQTT and shown on the Debug screen
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DeviceInfo {
+    pub wifi_ssid: String,
+    pub wifi_rssi: Option<i32>,
+    pub ip: Option<String>,
+    pub uptime_s: u64,
+    pub free_heap_b: Option<u32>,
+}
+
 /// Application errors
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AppError {
@@ -116,6 +126,8 @@ pub struct GlobalAppState {
     pub last_activity_at: Option<Instant>,
     /// Last time a UART telemetry frame was received (for Debug screen activity marker)
     pub last_uart_frame_at: Option<Instant>,
+    /// Board metadata (WiFi RSSI, IP, uptime, free heap)
+    pub device_info: DeviceInfo,
 }
 
 impl Default for GlobalAppState {
@@ -135,6 +147,7 @@ impl Default for GlobalAppState {
             screen_before_debug: None,
             last_activity_at: None,
             last_uart_frame_at: None,
+            device_info: DeviceInfo::default(),
         }
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -5,5 +5,5 @@ pub mod global_state;
 pub use app_events::AppEvent;
 pub use fsm::AppStateMachine;
 pub use global_state::{
-    AppError, ConnectionStatus, ExtractionState, GlobalAppState, MqttOutboundMessage,
+    AppError, ConnectionStatus, DeviceInfo, ExtractionState, GlobalAppState, MqttOutboundMessage,
 };


### PR DESCRIPTION
## Summary

- Adds `mara/status` MQTT topic published every 30s with board metadata: Wi-Fi SSID, RSSI (dBm), IP address, uptime (s), free heap (bytes)
- Stores metadata in `GlobalAppState` via new `DeviceInfo` struct and `AppEvent::DeviceInfoUpdated`
- Debug screen gets two new lines: `DEV: ssid=... rssi=...dBm` / `ip=... up=...s heap=...kB`
- Node-RED flow updated: new `mara/status` subscriber + 5 HA diagnostic sensors (uptime in min, RSSI with `signal_strength` device class, SSID, IP, free heap in kB)
- Simulator publishes stub values (`rssi=-65`, `ip=127.0.0.1`) on the same 30s cadence

## Test plan

- [x] Run simulator (`make sim`), open Debug screen — verify DEV lines appear with stub values
- [x] Check MQTT broker receives `mara/status` every ~30s with correct JSON shape
- [x] Import updated `docs/node-red-ha-bridge.json` into Node-RED, trigger Publish Discovery, verify 5 new sensors appear in HA under Lelit Mara device

🤖 Generated with [Claude Code](https://claude.com/claude-code)