### PR TITLE
fix: Wi-Fi/MQTT reconnection and connection event logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "maratui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "display-interface-spi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maratui"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 [features]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -249,7 +249,11 @@ fn run_app_hardware(mut app: impl MaraUiApp) {
             app.handle_event(AppEvent::DeviceInfoUpdated(DeviceInfo {
                 wifi_ssid: ssid,
                 wifi_rssi: query_wifi_rssi(),
-                ip: wifi.sta_netif().get_ip_info().ok().map(|i| i.ip.to_string()),
+                ip: wifi
+                    .sta_netif()
+                    .get_ip_info()
+                    .ok()
+                    .map(|i| i.ip.to_string()),
                 uptime_s: now.saturating_duration_since(boot_time).as_secs(),
                 free_heap_b: Some(query_free_heap()),
             }));

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -128,7 +128,7 @@ fn run_app_hardware(mut app: impl MaraUiApp) {
     app.render_image(terminal.backend_mut().display_mut());
     terminal.draw(|f| app.draw(f)).unwrap();
 
-    let (_wifi, initial_ip) = init_wifi(modem, &app_config);
+    let (mut wifi, _) = init_wifi(modem, &app_config);
     app.handle_event(AppEvent::WifiStatusChanged(ConnectionStatus::Connected));
 
     // ── MQTT ────────────────────────────────────────────────────────────────
@@ -187,6 +187,9 @@ fn run_app_hardware(mut app: impl MaraUiApp) {
 
     let boot_time = Instant::now();
     let mut last_status_at: Option<Instant> = None;
+    let mut last_wifi_check_at: Option<Instant> = None;
+    let mut wifi_reconnect_at: Option<Instant> = None;
+    let mut wifi_was_connected = true;
     let mut prev_had_telemetry = false;
 
     loop {
@@ -220,6 +223,14 @@ fn run_app_hardware(mut app: impl MaraUiApp) {
 
         if let Some(status_rx) = mqtt_status_rx.as_mut() {
             while let Ok(status) = status_rx.try_recv() {
+                if status == ConnectionStatus::Connected {
+                    let topic = format!("{}/cup_counter", app_config.mqtt.topic_prefix);
+                    if let Some(client) = mqtt_client.as_mut() {
+                        if let Err(e) = client.subscribe(&topic, QoS::AtMostOnce) {
+                            warn!("Failed to re-subscribe to {}: {:?}", topic, e);
+                        }
+                    }
+                }
                 app.handle_event(AppEvent::MqttStatusChanged(status));
             }
         }
@@ -238,10 +249,42 @@ fn run_app_hardware(mut app: impl MaraUiApp) {
             app.handle_event(AppEvent::DeviceInfoUpdated(DeviceInfo {
                 wifi_ssid: ssid,
                 wifi_rssi: query_wifi_rssi(),
-                ip: initial_ip.clone(),
+                ip: wifi.sta_netif().get_ip_info().ok().map(|i| i.ip.to_string()),
                 uptime_s: now.saturating_duration_since(boot_time).as_secs(),
                 free_heap_b: Some(query_free_heap()),
             }));
+        }
+
+        let should_check_wifi = last_wifi_check_at
+            .map(|t| now.saturating_duration_since(t) >= WIFI_CHECK_INTERVAL)
+            .unwrap_or(true);
+        if should_check_wifi {
+            last_wifi_check_at = Some(now);
+            let is_connected = query_wifi_rssi().is_some();
+            if is_connected != wifi_was_connected {
+                wifi_was_connected = is_connected;
+                if is_connected {
+                    info!("Wi-Fi reconnected");
+                    app.handle_event(AppEvent::WifiStatusChanged(ConnectionStatus::Connected));
+                } else {
+                    info!("Wi-Fi disconnected");
+                    app.handle_event(AppEvent::WifiStatusChanged(ConnectionStatus::Disconnected));
+                }
+            }
+            if !is_connected {
+                let should_reconnect = wifi_reconnect_at
+                    .map(|t| now.saturating_duration_since(t) >= WIFI_RECONNECT_INTERVAL)
+                    .unwrap_or(true);
+                if should_reconnect {
+                    wifi_reconnect_at = Some(now);
+                    info!("Wi-Fi disconnected, attempting reconnect");
+                    if let Err(e) = wifi.connect() {
+                        warn!("Wi-Fi reconnect failed: {:?}", e);
+                    }
+                }
+            } else {
+                wifi_reconnect_at = None;
+            }
         }
 
         for (topic_suffix, payload) in app.take_outbound_mqtt_messages() {
@@ -269,6 +312,8 @@ fn run_app_hardware(mut app: impl MaraUiApp) {
 }
 
 const STATUS_INTERVAL: Duration = Duration::from_secs(30);
+const WIFI_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+const WIFI_RECONNECT_INTERVAL: Duration = Duration::from_secs(15);
 const MIN_STAGE_MS: u64 = 800;
 
 fn min_stage_delay(started_at: Instant) {

--- a/src/state/fsm.rs
+++ b/src/state/fsm.rs
@@ -1,6 +1,6 @@
 use log::{error, info};
 
-use super::{AppError, AppEvent, DeviceInfo, ExtractionState, GlobalAppState};
+use super::{AppError, AppEvent, ConnectionStatus, DeviceInfo, ExtractionState, GlobalAppState};
 use crate::button::{Button, ButtonPressType};
 use crate::screens::Screen;
 use crate::telemetry::{TelemetryFrame, update_state_with_events};
@@ -87,10 +87,32 @@ impl AppStateMachine {
             }
 
             AppEvent::WifiStatusChanged(status) => {
+                match &status {
+                    ConnectionStatus::Connected | ConnectionStatus::Disconnected => {
+                        state.events_log.push_front(format!("Wi-Fi: {:?}", status));
+                        if state.events_log.len() > 10 {
+                            state.events_log.pop_back();
+                        }
+                    }
+                    _ => {}
+                }
                 state.wifi_status = status;
             }
 
             AppEvent::MqttStatusChanged(status) => {
+                let should_log = match &status {
+                    ConnectionStatus::Connected => {
+                        state.mqtt_status != ConnectionStatus::Connected
+                    }
+                    ConnectionStatus::Disconnected | ConnectionStatus::Error(_) => true,
+                    _ => false,
+                };
+                if should_log {
+                    state.events_log.push_front(format!("MQTT: {:?}", status));
+                    if state.events_log.len() > 10 {
+                        state.events_log.pop_back();
+                    }
+                }
                 state.mqtt_status = status;
             }
 

--- a/src/state/fsm.rs
+++ b/src/state/fsm.rs
@@ -101,9 +101,7 @@ impl AppStateMachine {
 
             AppEvent::MqttStatusChanged(status) => {
                 let should_log = match &status {
-                    ConnectionStatus::Connected => {
-                        state.mqtt_status != ConnectionStatus::Connected
-                    }
+                    ConnectionStatus::Connected => state.mqtt_status != ConnectionStatus::Connected,
                     ConnectionStatus::Disconnected | ConnectionStatus::Error(_) => true,
                     _ => false,
                 };


### PR DESCRIPTION
Wi-Fi dropped silently and permanently: status showed Connected
forever while RSSI returned None and MQTT hung in Connecting.

- Poll Wi-Fi health every 10s via RSSI; emit WifiStatusChanged on
  transitions so the debug screen reflects real state
- Attempt wifi.connect() (non-blocking ESP-IDF call) every 15s while
  disconnected so the stack re-associates when the AP comes back
- Replace stale boot-time IP with live netif query in DeviceInfoUpdated
- Re-subscribe to cup_counter MQTT topic on every Connected event so
  the subscription survives reconnects (was lost on broker drop/restore)
- Log Wi-Fi Connected/Disconnected and MQTT Connected/Disconnected/Error
  transitions to events_log so they appear on the debug screen

https://claude.ai/code/session_01QexXH2asfZeW8wpTA35Ttn