### PR TITLE
refactor: full codebase code review cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,14 @@ tui-widgets = {version = "0.7.0", default-features=false, features=["big-text"]}
 [build-dependencies]
 embuild = { version = "0.33", features = ["espidf"], optional = true }
 
+[lints.rust]
+unused = "warn"
+
+[lints.clippy]
+bool_assert_comparison = "warn"
+redundant_clone = "warn"
+needless_collect = "warn"
+
 [profile.release]
 opt-level = 3
 

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -12,13 +12,13 @@ use crate::screens::screen::Board;
 use crate::state::GlobalAppState;
 use crate::telemetry::{MachineMode, TelemetryFrame};
 
-const STYLE_GREEN:     Style = Style::new().fg(Color::Green);
-const STYLE_CYAN:      Style = Style::new().fg(Color::Cyan);
-const STYLE_RED:       Style = Style::new().fg(Color::Red);
-const STYLE_GRAY:      Style = Style::new().fg(Color::Gray);
+const STYLE_GREEN: Style = Style::new().fg(Color::Green);
+const STYLE_CYAN: Style = Style::new().fg(Color::Cyan);
+const STYLE_RED: Style = Style::new().fg(Color::Red);
+const STYLE_GRAY: Style = Style::new().fg(Color::Gray);
 const STYLE_DARK_GRAY: Style = Style::new().fg(Color::DarkGray);
-const STYLE_WHITE:     Style = Style::new().fg(Color::White);
-const STYLE_YELLOW:    Style = Style::new().fg(Color::Yellow);
+const STYLE_WHITE: Style = Style::new().fg(Color::White);
+const STYLE_YELLOW: Style = Style::new().fg(Color::Yellow);
 
 const BOILER_SCALE_MAX: u16 = 160;
 const SHOT_GAUGE_MAX_SECS: u64 = 30;
@@ -119,12 +119,28 @@ fn render_info_col(t_frame: &TelemetryFrame, area: Rect, buf: &mut Buffer) {
     render_hx_vgauge(t_frame.hx_now_c, hx_gauge_area, buf);
 
     let heat_span = Span::styled(
-        if t_frame.heating_on { "● HEAT" } else { "○ HEAT" },
-        if t_frame.heating_on { STYLE_GREEN } else { STYLE_DARK_GRAY },
+        if t_frame.heating_on {
+            "● HEAT"
+        } else {
+            "○ HEAT"
+        },
+        if t_frame.heating_on {
+            STYLE_GREEN
+        } else {
+            STYLE_DARK_GRAY
+        },
     );
     let pump_span = Span::styled(
-        if t_frame.pump_on { "● PUMP" } else { "○ PUMP" },
-        if t_frame.pump_on { STYLE_GREEN } else { STYLE_DARK_GRAY },
+        if t_frame.pump_on {
+            "● PUMP"
+        } else {
+            "○ PUMP"
+        },
+        if t_frame.pump_on {
+            STYLE_GREEN
+        } else {
+            STYLE_DARK_GRAY
+        },
     );
 
     Paragraph::new(vec![

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use ratatui::Frame;
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::Style;
+use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Padding, Paragraph, Widget};
 use tui_widgets::big_text::{BigText, PixelSize};
@@ -11,6 +11,14 @@ use tui_widgets::big_text::{BigText, PixelSize};
 use crate::screens::screen::Board;
 use crate::state::GlobalAppState;
 use crate::telemetry::{MachineMode, TelemetryFrame};
+
+const STYLE_GREEN:     Style = Style::new().fg(Color::Green);
+const STYLE_CYAN:      Style = Style::new().fg(Color::Cyan);
+const STYLE_RED:       Style = Style::new().fg(Color::Red);
+const STYLE_GRAY:      Style = Style::new().fg(Color::Gray);
+const STYLE_DARK_GRAY: Style = Style::new().fg(Color::DarkGray);
+const STYLE_WHITE:     Style = Style::new().fg(Color::White);
+const STYLE_YELLOW:    Style = Style::new().fg(Color::Yellow);
 
 const BOILER_SCALE_MAX: u16 = 160;
 const SHOT_GAUGE_MAX_SECS: u64 = 30;
@@ -61,12 +69,12 @@ impl Board for Dashboard {
 
 fn render_mode_banner(t_frame: &TelemetryFrame, area: Rect, buf: &mut Buffer) {
     let (label, style) = match t_frame.mode {
-        MachineMode::Coffee => ("═══ COFFEE MODE ═══", Style::new().green()),
+        MachineMode::Coffee => ("═══ COFFEE MODE ═══", STYLE_GREEN),
         MachineMode::SteamS | MachineMode::SteamV | MachineMode::SteamC => {
-            ("═══ STEAM MODE ═══", Style::new().cyan())
+            ("═══ STEAM MODE ═══", STYLE_CYAN)
         }
-        MachineMode::Offline => ("═══  OFFLINE  ═══", Style::new().red()),
-        MachineMode::Unknown(_) => ("═══  UNKNOWN  ═══", Style::new().gray()),
+        MachineMode::Offline => ("═══  OFFLINE  ═══", STYLE_RED),
+        MachineMode::Unknown(_) => ("═══  UNKNOWN  ═══", STYLE_GRAY),
     };
 
     Paragraph::new(Line::from(label))
@@ -82,14 +90,14 @@ fn render_cup_counter(count: Option<u64>, area: Rect, buf: &mut Buffer) {
 
     Paragraph::new(Line::from(format!("Cups brewed: {cups}")))
         .centered()
-        .style(Style::new().white())
+        .style(STYLE_WHITE)
         .render(area, buf);
 }
 
 fn render_info_col(t_frame: &TelemetryFrame, area: Rect, buf: &mut Buffer) {
     let block = Block::bordered()
         .border_type(BorderType::Rounded)
-        .border_style(Style::new().yellow());
+        .border_style(STYLE_YELLOW);
     let inner = block.inner(area);
     block.render(area, buf);
 
@@ -101,9 +109,9 @@ fn render_info_col(t_frame: &TelemetryFrame, area: Rect, buf: &mut Buffer) {
         Layout::horizontal([Constraint::Fill(1), Constraint::Length(2)]).areas(hx_area);
 
     Paragraph::new(vec![
-        Line::styled("HX", Style::new().dark_gray()),
+        Line::styled("HX", STYLE_DARK_GRAY),
         Line::raw(""),
-        Line::styled(format!("{}°", t_frame.hx_now_c), Style::new().cyan()),
+        Line::styled(format!("{}°", t_frame.hx_now_c), STYLE_CYAN),
     ])
     .centered()
     .render(hx_text_area, buf);
@@ -111,28 +119,12 @@ fn render_info_col(t_frame: &TelemetryFrame, area: Rect, buf: &mut Buffer) {
     render_hx_vgauge(t_frame.hx_now_c, hx_gauge_area, buf);
 
     let heat_span = Span::styled(
-        if t_frame.heating_on {
-            "● HEAT"
-        } else {
-            "○ HEAT"
-        },
-        if t_frame.heating_on {
-            Style::new().green()
-        } else {
-            Style::new().dark_gray()
-        },
+        if t_frame.heating_on { "● HEAT" } else { "○ HEAT" },
+        if t_frame.heating_on { STYLE_GREEN } else { STYLE_DARK_GRAY },
     );
     let pump_span = Span::styled(
-        if t_frame.pump_on {
-            "● PUMP"
-        } else {
-            "○ PUMP"
-        },
-        if t_frame.pump_on {
-            Style::new().green()
-        } else {
-            Style::new().dark_gray()
-        },
+        if t_frame.pump_on { "● PUMP" } else { "○ PUMP" },
+        if t_frame.pump_on { STYLE_GREEN } else { STYLE_DARK_GRAY },
     );
 
     Paragraph::new(vec![
@@ -167,10 +159,10 @@ fn render_hx_vgauge(temp: u16, area: Rect, buf: &mut Buffer) {
     let ideal_bot_row = temp_to_row(HX_IDEAL_LOW);
 
     let fill_style = match temp {
-        0..=87 => Style::new().white(),
-        88..=95 => Style::new().green(),
-        96..=100 => Style::new().yellow(),
-        _ => Style::new().red(),
+        0..=87 => STYLE_WHITE,
+        88..=95 => STYLE_GREEN,
+        96..=100 => STYLE_YELLOW,
+        _ => STYLE_RED,
     };
 
     let w = area.width as usize;
@@ -186,9 +178,9 @@ fn render_hx_vgauge(temp: u16, area: Rect, buf: &mut Buffer) {
         let (s, style) = if is_filled {
             (fill.as_str(), fill_style)
         } else if in_ideal {
-            (ideal.as_str(), Style::new().green())
+            (ideal.as_str(), STYLE_GREEN)
         } else {
-            (empty.as_str(), Style::new().dark_gray())
+            (empty.as_str(), STYLE_DARK_GRAY)
         };
 
         buf.set_string(area.x, y, s, style);
@@ -203,7 +195,7 @@ fn render_boiler_gauge(t_frame: &TelemetryFrame, area: Rect, buf: &mut Buffer) {
     let block = Block::bordered()
         .title("Boiler")
         .border_type(BorderType::Rounded)
-        .border_style(Style::new().yellow());
+        .border_style(STYLE_YELLOW);
     let inner = block.inner(area);
     block.render(area, buf);
 
@@ -214,7 +206,7 @@ fn render_boiler_gauge(t_frame: &TelemetryFrame, area: Rect, buf: &mut Buffer) {
     let Some(target) = t_frame.boiler_target_c else {
         Paragraph::new(Line::from("NO WATER"))
             .centered()
-            .style(Style::new().red())
+            .style(STYLE_RED)
             .render(inner, buf);
         return;
     };
@@ -225,11 +217,7 @@ fn render_boiler_gauge(t_frame: &TelemetryFrame, area: Rect, buf: &mut Buffer) {
     // Left label: "120°/138° "
     let label = format!("{:3}°/{:3}° ", now, target);
     let label_len = label.len() as u16; // all ASCII + °(1 display width each)
-    let label_style = if at_temp {
-        Style::new().green()
-    } else {
-        Style::new().yellow()
-    };
+    let label_style = if at_temp { STYLE_GREEN } else { STYLE_YELLOW };
     buf.set_string(inner.x, inner.y, &label, label_style);
 
     let bar_x = inner.x + label_len;
@@ -252,15 +240,15 @@ fn render_boiler_gauge(t_frame: &TelemetryFrame, area: Rect, buf: &mut Buffer) {
         let (ch, style) = if i < current_pos {
             // Filled portion — two-tone: warming → ready
             if i >= ready_pos {
-                ("█", Style::new().green())
+                ("█", STYLE_GREEN)
             } else {
-                ("█", Style::new().yellow())
+                ("█", STYLE_YELLOW)
             }
         } else if i == target_pos {
             // Target marker (current hasn't reached it yet)
-            ("│", Style::new().white())
+            ("│", STYLE_WHITE)
         } else {
-            ("─", Style::new().dark_gray())
+            ("─", STYLE_DARK_GRAY)
         };
         buf.set_string(x, inner.y, ch, style);
     }
@@ -275,7 +263,7 @@ fn render_shot_gauge(state: &GlobalAppState, area: Rect, buf: &mut Buffer) {
         .title_bottom("%")
         .title_alignment(ratatui::layout::HorizontalAlignment::Center)
         .border_type(BorderType::Rounded)
-        .border_style(Style::new().yellow());
+        .border_style(STYLE_YELLOW);
     let inner = block.inner(area);
     block.render(area, buf);
 
@@ -296,7 +284,7 @@ fn render_shot_gauge(state: &GlobalAppState, area: Rect, buf: &mut Buffer) {
         if is_filled {
             buf.set_string(inner.x, y, &fill, fill_style);
         } else {
-            buf.set_string(inner.x, y, &empty, Style::new().dark_gray());
+            buf.set_string(inner.x, y, &empty, STYLE_DARK_GRAY);
         }
     }
 }
@@ -310,14 +298,14 @@ fn render_timer(state: &GlobalAppState, area: Rect, frame: &mut Frame) {
     } else if state.extraction_state.last_extraction_duration().is_some() {
         shot_style(extraction_secs, false)
     } else {
-        Style::new().dark_gray()
+        STYLE_DARK_GRAY
     };
 
     let timer_block = Block::bordered()
         .title_bottom("Extraction")
         .title_alignment(ratatui::layout::HorizontalAlignment::Center)
         .border_type(BorderType::Rounded)
-        .border_style(Style::new().yellow())
+        .border_style(STYLE_YELLOW)
         .padding(Padding::top(1));
 
     let timer_inner = timer_block.inner(area);
@@ -369,16 +357,16 @@ fn current_extraction_secs(state: &GlobalAppState) -> u64 {
 fn shot_style(secs: u64, is_live: bool) -> Style {
     if is_live {
         match secs {
-            0..=19 => Style::new().white(),
-            20..=27 => Style::new().green(),
-            _ => Style::new().yellow(),
+            0..=19 => STYLE_WHITE,
+            20..=27 => STYLE_GREEN,
+            _ => STYLE_YELLOW,
         }
     } else {
         match secs {
-            0..=14 => Style::new().red(),
-            15..=19 => Style::new().yellow(),
-            20..=30 => Style::new().green(),
-            _ => Style::new().yellow(),
+            0..=14 => STYLE_RED,
+            15..=19 => STYLE_YELLOW,
+            20..=30 => STYLE_GREEN,
+            _ => STYLE_YELLOW,
         }
     }
 }

--- a/src/state/fsm.rs
+++ b/src/state/fsm.rs
@@ -175,7 +175,11 @@ impl AppStateMachine {
 
         // Extract Copy fields from last_frame before the mutable borrows below
         let (boiler_target, boiler_now_c, hx_now_c) = {
-            let last = state.machine_state.last_frame.as_ref().unwrap();
+            let last = state
+            .machine_state
+            .last_frame
+            .as_ref()
+            .expect("update_state_with_events always stores the frame in last_frame");
             (
                 last.boiler_target_c.map(f64::from).unwrap_or_default(),
                 f64::from(last.boiler_now_c),
@@ -213,24 +217,26 @@ impl AppStateMachine {
     }
 }
 
+fn json_opt_num<T: std::fmt::Display>(opt: Option<T>) -> String {
+    opt.map_or_else(|| "null".to_string(), |v| v.to_string())
+}
+
+fn json_opt_str(opt: Option<&str>) -> String {
+    opt.map_or_else(|| "null".to_string(), |s| format!("\"{}\"", s))
+}
+
 fn telemetry_payload(frame: &TelemetryFrame) -> String {
     format!(
         "{{\"mode\":\"{}\",\"sw\":\"{}\",\"boiler_now_c\":{},\"boiler_target_c\":{},\"hx_now_c\":{},\"boost_countdown_s\":{},\"heating_on\":{},\"pump_on\":{},\"no_water_code\":{}}}",
         frame.mode,
         frame.sw_version,
         frame.boiler_now_c,
-        frame
-            .boiler_target_c
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "null".to_string()),
+        json_opt_num(frame.boiler_target_c),
         frame.hx_now_c,
         frame.boost_countdown_s,
         frame.heating_on,
         frame.pump_on,
-        frame
-            .no_water_code
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "null".to_string())
+        json_opt_num(frame.no_water_code),
     )
 }
 
@@ -246,26 +252,14 @@ fn push_sample(buf: &mut std::collections::VecDeque<f64>, value: f64) {
 }
 
 fn device_status_payload(info: &DeviceInfo) -> String {
-    let rssi = info
-        .wifi_rssi
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| "null".to_string());
-    let ip = info
-        .ip
-        .as_deref()
-        .map(|s| format!("\"{}\"", s))
-        .unwrap_or_else(|| "null".to_string());
-    let heap = info
-        .free_heap_b
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| "null".to_string());
-    let tele_age = info
-        .last_telemetry_age_s
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| "null".to_string());
     format!(
         "{{\"uptime_s\":{},\"wifi_ssid\":\"{}\",\"wifi_rssi\":{},\"ip\":{},\"free_heap_b\":{},\"last_telemetry_age_s\":{}}}",
-        info.uptime_s, info.wifi_ssid, rssi, ip, heap, tele_age,
+        info.uptime_s,
+        info.wifi_ssid,
+        json_opt_num(info.wifi_rssi),
+        json_opt_str(info.ip.as_deref()),
+        json_opt_num(info.free_heap_b),
+        json_opt_num(info.last_telemetry_age_s),
     )
 }
 
@@ -325,7 +319,7 @@ mod tests {
         AppStateMachine::handle_event(
             &mut state,
             AppEvent::ShotEnded {
-                duration: duration.as_secs() as u64,
+                duration: duration.as_secs(),
             },
         );
 
@@ -455,7 +449,7 @@ mod tests {
         AppStateMachine::handle_event(
             &mut state,
             AppEvent::ShotEnded {
-                duration: duration.as_secs() as u64,
+                duration: duration.as_secs(),
             },
         );
 

--- a/src/state/fsm.rs
+++ b/src/state/fsm.rs
@@ -176,10 +176,10 @@ impl AppStateMachine {
         // Extract Copy fields from last_frame before the mutable borrows below
         let (boiler_target, boiler_now_c, hx_now_c) = {
             let last = state
-            .machine_state
-            .last_frame
-            .as_ref()
-            .expect("update_state_with_events always stores the frame in last_frame");
+                .machine_state
+                .last_frame
+                .as_ref()
+                .expect("update_state_with_events always stores the frame in last_frame");
             (
                 last.boiler_target_c.map(f64::from).unwrap_or_default(),
                 f64::from(last.boiler_now_c),

--- a/src/state/global_state.rs
+++ b/src/state/global_state.rs
@@ -156,11 +156,6 @@ impl Default for GlobalAppState {
 }
 
 impl GlobalAppState {
-    /// Create a new application state
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Get the duration of the current extraction in seconds
     pub fn extraction_duration_secs(&self) -> u64 {
         self.extraction_state

--- a/src/telemetry/telemetry.rs
+++ b/src/telemetry/telemetry.rs
@@ -221,7 +221,6 @@ pub enum AppEvent {
 #[derive(Debug)]
 pub struct MachineState {
     pub last_frame: Option<TelemetryFrame>,
-    pub last_update: Option<Instant>,
     pub shot_started_at: Option<Instant>,
     pub last_graph_sample_at: Option<Instant>,
     pub target_boiler_data: VecDeque<f64>,
@@ -238,7 +237,6 @@ impl Default for MachineState {
     fn default() -> Self {
         Self {
             last_frame: None,
-            last_update: None,
             shot_started_at: None,
             last_graph_sample_at: None,
             target_boiler_data: VecDeque::with_capacity(300),
@@ -349,7 +347,6 @@ pub fn update_state_with_events(
         _ => {}
     }
 
-    state.last_update = Some(now);
     let is_extracting = frame.pump_on;
     state.last_frame = Some(frame);
     let snapshot = Snapshot { is_extracting };
@@ -373,8 +370,8 @@ mod tests {
         assert_eq!(f.no_water_code, None);
         assert_eq!(f.hx_now_c, 35);
         assert_eq!(f.boost_countdown_s, 0);
-        assert_eq!(f.heating_on, true);
-        assert_eq!(f.pump_on, false);
+        assert!(f.heating_on);
+        assert!(!f.pump_on);
     }
 
     #[test]
@@ -382,8 +379,8 @@ mod tests {
         let f = parse_uart_line("C1.10,037,L65,035,0000,0,0").unwrap();
         assert_eq!(f.boiler_target_c, None);
         assert_eq!(f.no_water_code, Some(65));
-        assert_eq!(f.heating_on, false);
-        assert_eq!(f.pump_on, false);
+        assert!(!f.heating_on);
+        assert!(!f.pump_on);
     }
 
     #[test]
@@ -395,7 +392,7 @@ mod tests {
         assert_eq!(f.boiler_target_c, None);
         assert_eq!(f.no_water_code, None);
         assert_eq!(f.hx_now_c, 67);
-        assert_eq!(f.pump_on, false);
+        assert!(!f.pump_on);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Dead code removed**: `MachineState::last_update` field (declared and set, never read); `GlobalAppState::new()` (pure delegation to `Default::default()`)
- **Rust idiom fixes**: redundant `as u64` casts on `Duration::as_secs()`, bool assertion anti-patterns (`assert_eq!(x, true)` → `assert!(x)`), bare `.unwrap()` in `handle_telemetry_frame` replaced with `.expect()` carrying an explanatory message
- **Render hot path**: extracted 7 module-level `const Style` values in `dashboard.rs`, eliminating ~15 `Style::new()` constructions per render tick (compiler folds these at compile time)
- **JSON helpers**: extracted `json_opt_num` / `json_opt_str` in `fsm.rs`, collapsing 6 repeated `map().unwrap_or_else(|| "null".to_string())` patterns into reusable helpers
- **Lint setup**: added `[lints.clippy]` section to `Cargo.toml` (`bool_assert_comparison`, `redundant_clone`, `needless_collect`) to catch future regressions automatically

## Test plan

- [x] `cargo test --no-default-features --features simulator --target x86_64-unknown-linux-gnu` — 35/35 pass
- [x] `cargo clippy --no-default-features --features simulator --target x86_64-unknown-linux-gnu` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)