### PR TITLE
chore: remove unused direct dependencies libc and strum_macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,11 @@ display-interface-spi = { version = "0.5.0", optional = true }
 embedded-graphics-simulator = { version = "0.8.0", optional = true }
 esp-idf-svc = { version = "0.51", features = ["critical-section"], optional = true }
 ili9341 = { version = "0.6.0", optional = true }
-libc = "0.2"
 log = "0.4.29"
 mousefood = { version = "0.5.0", default-features=false, features = ["fonts"] }
 ratatui = {version = "0.30.0", default-features = false}
 rumqttc = { version = "0.24.0", optional = true }
 strum = "0.27.2"
-strum_macros = "0.27.2"
 tui-widgets = {version = "0.7.0", default-features=false, features=["big-text"]}
 
 [build-dependencies]


### PR DESCRIPTION
## Summary

- Remove `libc = "0.2"` — not referenced anywhere in `src/`; pulled in transitively by `sdl2-sys` anyway
- Remove `strum_macros = "0.27.2"` — redundant since strum 0.26+, which re-exports its proc-macros; the codebase already uses `use strum::{Display, EnumIter, FromRepr}` with no direct `strum_macros::` imports

## Test plan

- [x] `cargo check --no-default-features --features simulator --target aarch64-apple-darwin` passes cleanly