### PR TITLE
test: expand unit test coverage to 80%+ on logic modules

### DIFF
--- a/src/button.rs
+++ b/src/button.rs
@@ -78,3 +78,87 @@ impl ButtonState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_button_press_type_display() {
+        assert_eq!(ButtonPressType::Short.to_string(), "Short Press");
+        assert_eq!(ButtonPressType::Long.to_string(), "Long Press");
+    }
+
+    #[test]
+    fn test_button_display() {
+        assert_eq!(
+            Button::Button1(ButtonPressType::Short).to_string(),
+            "Button 1 (Short Press)"
+        );
+        assert_eq!(
+            Button::Button1(ButtonPressType::Long).to_string(),
+            "Button 1 (Long Press)"
+        );
+    }
+
+    #[test]
+    fn test_button_is_short_press() {
+        assert!(Button::Button1(ButtonPressType::Short).is_short_press());
+        assert!(!Button::Button1(ButtonPressType::Long).is_short_press());
+    }
+
+    #[test]
+    fn test_button_is_long_press() {
+        assert!(Button::Button1(ButtonPressType::Long).is_long_press());
+        assert!(!Button::Button1(ButtonPressType::Short).is_long_press());
+    }
+
+    #[test]
+    fn test_button_state_short_press() {
+        let mut state = ButtonState::default();
+        let mut received: Option<ButtonPressType> = None;
+
+        // Press
+        state.update(true, |_| {});
+        // Release immediately → short press
+        state.update(false, |t| received = Some(t));
+
+        assert_eq!(received, Some(ButtonPressType::Short));
+    }
+
+    #[test]
+    fn test_button_state_no_callback_when_not_pressed() {
+        let mut state = ButtonState::default();
+        let mut called = false;
+
+        state.update(false, |_| called = true);
+
+        assert!(!called);
+    }
+
+    #[test]
+    fn test_button_state_held_does_not_fire() {
+        let mut state = ButtonState::default();
+        let mut count = 0;
+
+        // Multiple held-down ticks without release
+        state.update(true, |_| count += 1);
+        state.update(true, |_| count += 1);
+        state.update(true, |_| count += 1);
+
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    #[ignore = "requires 600ms sleep to cross the long-press threshold"]
+    fn test_button_state_long_press() {
+        let mut state = ButtonState::default();
+        let mut received: Option<ButtonPressType> = None;
+
+        state.update(true, |_| {});
+        std::thread::sleep(std::time::Duration::from_millis(600));
+        state.update(false, |t| received = Some(t));
+
+        assert_eq!(received, Some(ButtonPressType::Long));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -215,10 +215,12 @@ mod tests {
 
         let result = AppConfig::from_env();
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid MARATUI_MQTT_ENABLED value"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid MARATUI_MQTT_ENABLED value")
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,3 +121,133 @@ fn build_time_setting(name: &str) -> Option<&'static str> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Serialize env-mutating tests so parallel test threads don't interfere.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Set the minimum env vars needed for a predictable config, overriding any build-time baked values.
+    fn set_base_env() {
+        unsafe {
+            std::env::set_var("MARATUI_MQTT_ENABLED", "true");
+            std::env::set_var("MARATUI_MQTT_URL", "mqtt://broker.emqx.io:1883");
+            std::env::set_var("MARATUI_MQTT_CLIENT_ID", "test-client");
+            std::env::set_var("MARATUI_MQTT_TOPIC_PREFIX", "maratui");
+            std::env::remove_var("MARATUI_MQTT_USERNAME");
+            std::env::remove_var("MARATUI_MQTT_PASSWORD");
+            std::env::remove_var("MARATUI_WIFI_SSID");
+            std::env::remove_var("MARATUI_WIFI_PASSWORD");
+        }
+    }
+
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn test_default_config_succeeds_in_simulator() {
+        let _lock = lock();
+        set_base_env();
+
+        let cfg = AppConfig::from_env().expect("default config should succeed in simulator mode");
+        // MQTT fields are fully controlled by set_base_env; wifi may be present if baked into
+        // the binary at compile time from a local .env file, so we do not assert on it here.
+        assert!(cfg.mqtt.enabled);
+        assert_eq!(cfg.mqtt.topic_prefix, "maratui");
+    }
+
+    #[test]
+    fn test_wifi_config_set_via_env() {
+        let _lock = lock();
+        set_base_env();
+        unsafe {
+            std::env::set_var("MARATUI_WIFI_SSID", "my_ssid");
+            std::env::set_var("MARATUI_WIFI_PASSWORD", "secret");
+        }
+
+        let cfg = AppConfig::from_env().unwrap();
+        let wifi = cfg.wifi.expect("wifi config should be present");
+        assert_eq!(wifi.ssid, "my_ssid");
+        assert_eq!(wifi.password, "secret");
+    }
+
+    #[test]
+    fn test_mqtt_disabled_via_env() {
+        let _lock = lock();
+        set_base_env();
+        unsafe { std::env::set_var("MARATUI_MQTT_ENABLED", "false") };
+
+        let cfg = AppConfig::from_env().unwrap();
+        assert!(!cfg.mqtt.enabled);
+    }
+
+    #[test]
+    fn test_mqtt_enabled_accepts_all_truthy_values() {
+        let _lock = lock();
+        for val in &["1", "true", "yes", "on", "TRUE", "YES"] {
+            set_base_env();
+            unsafe { std::env::set_var("MARATUI_MQTT_ENABLED", val) };
+            let cfg = AppConfig::from_env().unwrap();
+            assert!(cfg.mqtt.enabled, "expected enabled for value '{val}'");
+        }
+    }
+
+    #[test]
+    fn test_mqtt_enabled_accepts_all_falsy_values() {
+        let _lock = lock();
+        for val in &["0", "false", "no", "off"] {
+            set_base_env();
+            unsafe { std::env::set_var("MARATUI_MQTT_ENABLED", val) };
+            let cfg = AppConfig::from_env().unwrap();
+            assert!(!cfg.mqtt.enabled, "expected disabled for value '{val}'");
+        }
+    }
+
+    #[test]
+    fn test_mqtt_enabled_invalid_value_returns_error() {
+        let _lock = lock();
+        set_base_env();
+        unsafe { std::env::set_var("MARATUI_MQTT_ENABLED", "maybe") };
+
+        let result = AppConfig::from_env();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid MARATUI_MQTT_ENABLED value"));
+    }
+
+    #[test]
+    fn test_mqtt_custom_url_and_prefix() {
+        let _lock = lock();
+        set_base_env();
+        unsafe {
+            std::env::set_var("MARATUI_MQTT_URL", "mqtt://localhost:1883");
+            std::env::set_var("MARATUI_MQTT_TOPIC_PREFIX", "home");
+            std::env::set_var("MARATUI_MQTT_CLIENT_ID", "my-device");
+        }
+
+        let cfg = AppConfig::from_env().unwrap();
+        assert_eq!(cfg.mqtt.url, "mqtt://localhost:1883");
+        assert_eq!(cfg.mqtt.topic_prefix, "home");
+        assert_eq!(cfg.mqtt.client_id, "my-device");
+    }
+
+    #[test]
+    fn test_mqtt_credentials_set() {
+        let _lock = lock();
+        set_base_env();
+        unsafe {
+            std::env::set_var("MARATUI_MQTT_USERNAME", "user");
+            std::env::set_var("MARATUI_MQTT_PASSWORD", "pass");
+        }
+
+        let cfg = AppConfig::from_env().unwrap();
+        assert_eq!(cfg.mqtt.username.as_deref(), Some("user"));
+        assert_eq!(cfg.mqtt.password.as_deref(), Some("pass"));
+    }
+}

--- a/src/screens/screen.rs
+++ b/src/screens/screen.rs
@@ -36,3 +36,31 @@ pub trait Board {
     /// Render the screen with the given application state
     fn render(state: &GlobalAppState, area: Rect, frame: &mut Frame);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_screen_next_cycles_dashboard_graphs() {
+        assert_eq!(Screen::Dashboard.next(), Screen::Graphs);
+        assert_eq!(Screen::Graphs.next(), Screen::Dashboard);
+    }
+
+    #[test]
+    fn test_screen_next_debug_stays() {
+        assert_eq!(Screen::Debug.next(), Screen::Debug);
+    }
+
+    #[test]
+    fn test_screen_previous_mirrors_next() {
+        assert_eq!(Screen::Dashboard.previous(), Screen::Dashboard.next());
+        assert_eq!(Screen::Graphs.previous(), Screen::Graphs.next());
+        assert_eq!(Screen::Debug.previous(), Screen::Debug.next());
+    }
+
+    #[test]
+    fn test_screen_default_is_dashboard() {
+        assert_eq!(Screen::default(), Screen::Dashboard);
+    }
+}

--- a/src/state/app_events.rs
+++ b/src/state/app_events.rs
@@ -157,6 +157,7 @@ impl std::fmt::Display for AppEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::telemetry::MachineMode;
 
     #[test]
     fn test_app_event_from_telemetry() {
@@ -166,12 +167,48 @@ mod tests {
     }
 
     #[test]
+    fn test_from_telemetry_all_variants() {
+        assert_eq!(
+            AppEvent::from_telemetry(TelemetryEvent::ShotEnded { duration: 30 }),
+            AppEvent::ShotEnded { duration: 30 }
+        );
+        assert_eq!(
+            AppEvent::from_telemetry(TelemetryEvent::ShotAborted { duration: 5 }),
+            AppEvent::ShotAborted { duration: 5 }
+        );
+        assert_eq!(
+            AppEvent::from_telemetry(TelemetryEvent::ModeChanged {
+                from: MachineMode::Coffee,
+                to: MachineMode::SteamS
+            }),
+            AppEvent::ModeChanged {
+                from: MachineMode::Coffee,
+                to: MachineMode::SteamS
+            }
+        );
+        assert_eq!(
+            AppEvent::from_telemetry(TelemetryEvent::WaterRefillNeeded { code: 65 }),
+            AppEvent::WaterRefillNeeded { code: 65 }
+        );
+        assert_eq!(
+            AppEvent::from_telemetry(TelemetryEvent::WaterRefillCleared),
+            AppEvent::WaterRefillCleared
+        );
+    }
+
+    #[test]
     fn test_app_event_is_telemetry_event() {
         assert!(AppEvent::ShotStarted.is_telemetry_event());
         assert!(AppEvent::ShotEnded { duration: 30 }.is_telemetry_event());
         assert!(AppEvent::ShotAborted { duration: 5 }.is_telemetry_event());
         assert!(AppEvent::WaterRefillNeeded { code: 65 }.is_telemetry_event());
         assert!(AppEvent::WaterRefillCleared.is_telemetry_event());
+        assert!(AppEvent::ModeChanged {
+            from: MachineMode::Coffee,
+            to: MachineMode::SteamS
+        }
+        .is_telemetry_event());
+        assert!(AppEvent::CupCounterUpdated { cups: 1 }.is_telemetry_event());
 
         // Infrastructure events must NOT appear in the telemetry log
         assert!(
@@ -182,7 +219,6 @@ mod tests {
             !AppEvent::MqttStatusChanged(crate::state::ConnectionStatus::Connected)
                 .is_telemetry_event()
         );
-        assert!(AppEvent::CupCounterUpdated { cups: 1 }.is_telemetry_event());
         assert!(
             !AppEvent::PublishMqttEvent {
                 topic_suffix: "t".into(),
@@ -190,13 +226,107 @@ mod tests {
             }
             .is_telemetry_event()
         );
+        assert!(!AppEvent::NextScreen.is_telemetry_event());
+        assert!(!AppEvent::PreviousScreen.is_telemetry_event());
+        assert!(!AppEvent::DebugScreen.is_telemetry_event());
+        assert!(!AppEvent::ErrorOccurred { error: "e".into() }.is_telemetry_event());
+        assert!(!AppEvent::ErrorCleared.is_telemetry_event());
+        assert!(!AppEvent::LoadingComplete.is_telemetry_event());
+    }
 
+    #[test]
+    fn test_app_event_is_ui_event() {
         assert!(AppEvent::NextScreen.is_ui_event());
+        assert!(AppEvent::PreviousScreen.is_ui_event());
+        assert!(AppEvent::DebugScreen.is_ui_event());
+        assert!(AppEvent::ErrorOccurred { error: "oops".into() }.is_ui_event());
+        assert!(AppEvent::ErrorCleared.is_ui_event());
+
+        // Non-UI events
+        assert!(!AppEvent::ShotStarted.is_ui_event());
+        assert!(!AppEvent::ShotEnded { duration: 30 }.is_ui_event());
+        assert!(!AppEvent::WaterRefillCleared.is_ui_event());
+        assert!(!AppEvent::CupCounterUpdated { cups: 1 }.is_ui_event());
+        assert!(
+            !AppEvent::WifiStatusChanged(crate::state::ConnectionStatus::Connected).is_ui_event()
+        );
+        assert!(!AppEvent::LoadingComplete.is_ui_event());
     }
 
     #[test]
     fn test_app_event_display() {
-        let event = AppEvent::ShotStarted;
-        assert_eq!(event.to_string(), "Shot Started");
+        assert_eq!(AppEvent::ShotStarted.to_string(), "Shot Started");
+        assert_eq!(
+            AppEvent::ShotEnded { duration: 42 }.to_string(),
+            "Shot Ended (42 s)"
+        );
+        assert_eq!(
+            AppEvent::ShotAborted { duration: 3 }.to_string(),
+            "Shot Aborted (3 s)"
+        );
+        assert_eq!(
+            AppEvent::ModeChanged {
+                from: MachineMode::Coffee,
+                to: MachineMode::SteamS
+            }
+            .to_string(),
+            "Mode Changed: Coffee → Steam"
+        );
+        assert_eq!(
+            AppEvent::WaterRefillNeeded { code: 7 }.to_string(),
+            "Water Refill Needed (code: 7)"
+        );
+        assert_eq!(
+            AppEvent::WaterRefillCleared.to_string(),
+            "Water Refill Cleared"
+        );
+        assert_eq!(AppEvent::NextScreen.to_string(), "Next Screen");
+        assert_eq!(AppEvent::PreviousScreen.to_string(), "Previous Screen");
+        assert_eq!(AppEvent::DebugScreen.to_string(), "Debug Screen");
+        assert_eq!(
+            AppEvent::ErrorOccurred {
+                error: "boom".into()
+            }
+            .to_string(),
+            "Error: boom"
+        );
+        assert_eq!(AppEvent::ErrorCleared.to_string(), "Error Cleared");
+        assert_eq!(
+            AppEvent::WifiStatusChanged(crate::state::ConnectionStatus::Connected).to_string(),
+            "Wi-Fi status: Connected"
+        );
+        assert_eq!(
+            AppEvent::MqttStatusChanged(crate::state::ConnectionStatus::Disconnected).to_string(),
+            "MQTT status: Disconnected"
+        );
+        assert_eq!(
+            AppEvent::CupCounterUpdated { cups: 5 }.to_string(),
+            "Cup counter updated: 5"
+        );
+        assert_eq!(
+            AppEvent::PublishMqttEvent {
+                topic_suffix: "evt".into(),
+                payload: "{}".into()
+            }
+            .to_string(),
+            "Publish MQTT event: suffix='evt' payload='{}'"
+        );
+        assert_eq!(
+            AppEvent::DeviceInfoUpdated(crate::state::DeviceInfo {
+                uptime_s: 120,
+                ..Default::default()
+            })
+            .to_string(),
+            "Device info updated (uptime=120s)"
+        );
+        assert_eq!(
+            AppEvent::LoadingStage {
+                message: "Connecting",
+                progress: 50
+            }
+            .to_string(),
+            "Loading [50%]: Connecting"
+        );
+        assert_eq!(AppEvent::LoadingComplete.to_string(), "Loading complete");
     }
 }

--- a/src/state/app_events.rs
+++ b/src/state/app_events.rs
@@ -203,11 +203,13 @@ mod tests {
         assert!(AppEvent::ShotAborted { duration: 5 }.is_telemetry_event());
         assert!(AppEvent::WaterRefillNeeded { code: 65 }.is_telemetry_event());
         assert!(AppEvent::WaterRefillCleared.is_telemetry_event());
-        assert!(AppEvent::ModeChanged {
-            from: MachineMode::Coffee,
-            to: MachineMode::SteamS
-        }
-        .is_telemetry_event());
+        assert!(
+            AppEvent::ModeChanged {
+                from: MachineMode::Coffee,
+                to: MachineMode::SteamS
+            }
+            .is_telemetry_event()
+        );
         assert!(AppEvent::CupCounterUpdated { cups: 1 }.is_telemetry_event());
 
         // Infrastructure events must NOT appear in the telemetry log
@@ -239,7 +241,12 @@ mod tests {
         assert!(AppEvent::NextScreen.is_ui_event());
         assert!(AppEvent::PreviousScreen.is_ui_event());
         assert!(AppEvent::DebugScreen.is_ui_event());
-        assert!(AppEvent::ErrorOccurred { error: "oops".into() }.is_ui_event());
+        assert!(
+            AppEvent::ErrorOccurred {
+                error: "oops".into()
+            }
+            .is_ui_event()
+        );
         assert!(AppEvent::ErrorCleared.is_ui_event());
 
         // Non-UI events


### PR DESCRIPTION
## Summary

Adds unit tests to four logic-heavy modules that had little or no coverage, bringing them all to 80%+. The rendering and platform-setup files (SDL2-dependent) remain untestable at this layer without a major refactor.

## Changes

**`src/state/app_events.rs`** — 57.7% → 100%
- Tests for all `from_telemetry` variants (was only ShotStarted)
- Full `is_telemetry_event` / `is_ui_event` coverage incl. ModeChanged and negative cases
- `Display` tests for every AppEvent variant

**`src/screens/screen.rs`** — 77.8% → 100%
- Tests for `Screen::next()` on all three variants (Dashboard, Graphs, Debug)
- Tests for `Screen::previous()` and default value

**`src/button.rs`** — 0% → 80.7%
- Tests for `ButtonPressType` and `Button` Display impls
- Tests for `is_short_press` / `is_long_press`
- Tests for `ButtonState::update` — short press, held (no fire), no-press idle
- Long-press test exists but is `#[ignore]`-d (requires 600 ms sleep)

**`src/config.rs`** — 0% → 89%
- Tests for `AppConfig::from_env()` with explicit env-var overrides
- Covers all truthy/falsy `MARATUI_MQTT_ENABLED` values and the invalid-value error path
- Env tests serialized via a module-level `Mutex` to avoid parallel interference
- Build-time baked values (from local `.env`) are overridden by `set_var` in each test

## Files Changed

| File | Type | Change |
|---|---|---|
| `src/state/app_events.rs` | Tests | Modified |
| `src/screens/screen.rs` | Tests | Modified |
| `src/button.rs` | Tests | Modified |
| `src/config.rs` | Tests | Modified |

## Testing

```
cargo test --no-default-features --features simulator --target aarch64-apple-darwin
# Result: 58 passed; 0 failed; 1 ignored
```

Coverage measured with `cargo-llvm-cov` (stable toolchain + SDL2 via Homebrew).

## Related Issues

None